### PR TITLE
Add one-hot GMM diffusion option

### DIFF
--- a/lib/models/diffusions/gaussian_flow.py
+++ b/lib/models/diffusions/gaussian_flow.py
@@ -14,7 +14,7 @@ from mmgen.models.builder import MODULES, build_module
 from mmgen.models.diffusions.utils import _get_noise_batch
 
 from . import schedulers
-from lib.ops.gmflow_ops.gmflow_ops import gm_to_mean, gm_to_sample
+from lib.ops.gmflow_ops.gmflow_ops import gm_to_mean, gm_to_sample, gm_to_onehot
 
 
 @torch.jit.script
@@ -134,7 +134,7 @@ class GaussianFlow(nn.Module):
         cfg.update(test_cfg_override)
 
         output_mode = cfg.get('output_mode', 'mean')
-        assert output_mode in ['mean', 'sample']
+        assert output_mode in ['mean', 'sample', 'onehot']
 
         sampler = cfg.get('sampler', 'FlowMatchEulerDiscrete')
         sampler_class = getattr(diffusers.schedulers, sampler + 'Scheduler', None)
@@ -179,6 +179,8 @@ class GaussianFlow(nn.Module):
 
                 if output_mode == 'mean':
                     denoising_output = gm_to_mean(denoising_output)
+                elif output_mode == 'onehot':
+                    denoising_output = gm_to_onehot(denoising_output)
                 else:
                     denoising_output = gm_to_sample(denoising_output).squeeze(-4)
 

--- a/lib/models/diffusions/gmflow.py
+++ b/lib/models/diffusions/gmflow.py
@@ -14,7 +14,7 @@ from mmgen.models.diffusions.utils import _get_noise_batch
 
 from . import GaussianFlow, schedulers
 from lib.ops.gmflow_ops.gmflow_ops import (
-    gm_to_sample, gm_to_mean, gaussian_samples_to_gm_samples, gm_samples_to_gaussian_samples,
+    gm_to_sample, gm_to_mean, gm_to_onehot, gaussian_samples_to_gm_samples, gm_samples_to_gaussian_samples,
     iso_gaussian_mul_iso_gaussian, gm_mul_iso_gaussian, gm_to_iso_gaussian, gm_spectral_logprobs)
 
 
@@ -240,11 +240,13 @@ class GMFlowMixin:
         return samples, spectral_samples
 
     def gm_to_model_output(self, gm, output_mode, power_spectrum=None, generator=None):
-        assert output_mode in ['mean', 'sample']
+        assert output_mode in ['mean', 'sample', 'onehot']
         if output_mode == 'mean':
             output = gm_to_mean(gm)
-        else:  # sample
+        elif output_mode == 'sample':
             output = self.gm_sample(gm, power_spectrum, generator=generator)[0].squeeze(-4)
+        else:
+            output = gm_to_onehot(gm)
         return output
 
     def gm_2nd_order(
@@ -428,7 +430,7 @@ class GMFlow(GaussianFlow, GMFlowMixin):
         cfg.update(test_cfg_override)
 
         output_mode = cfg.get('output_mode', 'mean')
-        assert output_mode in ['mean', 'sample']
+        assert output_mode in ['mean', 'sample', 'onehot']
 
         sampler = cfg['sampler']
         sampler_class = getattr(diffusers.schedulers, sampler + 'Scheduler', None)

--- a/lib/ops/gmflow_ops/gmflow_ops.py
+++ b/lib/ops/gmflow_ops/gmflow_ops.py
@@ -561,6 +561,39 @@ def gm_to_mean(gm, gm_power=1):
     return gm_to_mean_jit(gm_means, gm_logweights, gm_power)
 
 
+def gm_to_onehot(gm, gm_power=1):
+    """Return the mean of the most probable Gaussian component.
+
+    Args:
+        gm (dict):
+            means (torch.Tensor): (bs, *, num_gaussians, out_channels, h, w)
+            logstds (torch.Tensor): (bs, *, 1, 1, 1, 1)
+            logweights (torch.Tensor): (bs, *, num_gaussians, 1, h, w)
+            or
+            means (torch.Tensor): (bs, *, num_gaussians, h, w, out_channels)
+            covs (torch.Tensor): (bs, *, 1 or num_gaussians, h, w, out_channels, out_channels)
+            logweights (torch.Tensor): (bs, *, num_gaussians, h, w)
+        gm_power (float): optional weight sharpening factor.
+
+    Returns:
+        torch.Tensor: (bs, *, out_channels, h, w)
+    """
+    gm_means = gm['means']
+    gm_logweights = gm['logweights']
+    if 'covs' in gm:
+        batch_shapes = gm_means.shape[:-4]
+        num_gaussians, h, w, out_channels = gm_means.shape[-4:]
+        batch_numel = batch_shapes.numel()
+        gm_means = gm_means.reshape(
+            batch_numel, num_gaussians, h, w, out_channels
+        ).permute(0, 1, 4, 2, 3).reshape(*batch_shapes, num_gaussians, out_channels, h, w)
+        gm_logweights = gm_logweights.unsqueeze(-3)
+    scores = gm_logweights * gm_power
+    inds = scores.argmax(dim=-4, keepdim=True)
+    mean = gm_means.gather(dim=-4, index=inds.expand_as(gm_means)).squeeze(-4)
+    return mean
+
+
 def gm_to_sample(
         gm,
         gm_power=1,


### PR DESCRIPTION
## Summary
- add `gm_to_onehot` for selecting the most probable Gaussian component
- support new `output_mode="onehot"` in GaussianFlow and GMFlow sampling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896db71d154832e960b4cb0316e75ce